### PR TITLE
:wrench: add file associations for nginx language

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "engines": {
         "vscode": "^1.32.0"
     },
-	"repository": {
-	    "type": "GitHub",
-	    "url": "https://github.com/william-voyek/vscode-nginx"
-	},
+    "repository": {
+        "type": "GitHub",
+        "url": "https://github.com/william-voyek/vscode-nginx"
+    },
     "categories": [
         "Programming Languages"
     ],
@@ -18,7 +18,7 @@
         "languages": [{
             "id": "nginx",
             "aliases": ["NGINX Conf", "nginx"],
-            "extensions": [".conf",".nginx"],
+            "extensions": ["nginx.conf", ".conf", ".nginx"],
             "configuration": "./language-configuration.json"
         }],
         "grammars": [{

--- a/syntaxes/nginx.tmLanguage.json
+++ b/syntaxes/nginx.tmLanguage.json
@@ -3,7 +3,14 @@
     "fileTypes": [
         "conf",
         "nginx",
-        "nginx.conf"
+        "nginx.conf",
+        "mime.type",
+        "fastcgi_params",
+        "proxy_params",
+        "scgi_params",
+        "uwsgi_params",
+        "fastcgi-php.conf",
+        "fastcgi.conf"
     ],
     "foldingStartMarker": "\\{\\s*$",
     "foldingStopMarker": "^\\s*\\}",

--- a/syntaxes/nginx.tmLanguage.json
+++ b/syntaxes/nginx.tmLanguage.json
@@ -2,7 +2,8 @@
     "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
     "fileTypes": [
         "conf",
-        "nginx"
+        "nginx",
+        "nginx.conf"
     ],
     "foldingStartMarker": "\\{\\s*$",
     "foldingStopMarker": "^\\s*\\}",


### PR DESCRIPTION
William, 

I hope you are able to accept this, and also see my question below.

---
Add file associations for `nginx.conf` and standard include files.

- [x] nginx.conf
- [x] mime.type
- [x] fastcgi_params
- [x] scgi_params
- [x] uwsgi_params
- [x] proxy_params
- [x] fastcgi-php.conf
- [x] fastcgi.conf

---

Checkout the nginx [tmLanguage](https://github.com/brandonwamboldt/sublime-nginx/blob/master/Syntaxes/nginx.tmLanguage) definition at [sublime-nginx](https://github.com/brandonwamboldt/sublime-nginx).

Are you interested in incorporating the language definition from the 
[sublime-nginx](https://github.com/brandonwamboldt/sublime-nginx) repo?

https://github.com/brandonwamboldt/sublime-nginx/blob/master/Syntaxes/nginx.tmLanguage

